### PR TITLE
docs: add GitHub Copilot instructions and project rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,20 +1,192 @@
-# Copilot instructions for SistemaTickets
+# Project Copilot Instructions — Ticket Microservices System
 
-## Big picture
-- Backend is organized as service folders under backend/: assignment-service, notification-service, and ticket-service. Only ticket-service currently contains code; the other folders are empty placeholders for future microservices.
-- ticket-service is a Django project (project package ticket_service) with a single app tickets and a single model `Ticket` (title/description/status/created_at). See [backend/ticket-service/tickets/models.py](backend/ticket-service/tickets/models.py).
-- REST framework is installed in settings, but no API views or routes are defined yet (urls only contains the admin route). See [backend/ticket-service/ticket_service/settings.py](backend/ticket-service/ticket_service/settings.py) and [backend/ticket-service/ticket_service/urls.py](backend/ticket-service/ticket_service/urls.py).
-- Messaging integration is planned via a messaging package with pika in dependencies; current messaging modules are empty stubs. See [backend/ticket-service/messaging](backend/ticket-service/messaging) and [backend/ticket-service/requirements.txt](backend/ticket-service/requirements.txt).
+## Architecture Overview
 
-## Data & dependencies
-- Database is SQLite at backend/ticket-service/db.sqlite3 configured via Django settings. See [backend/ticket-service/ticket_service/settings.py](backend/ticket-service/ticket_service/settings.py).
-- Python dependencies are pinned in requirements.txt; include Django, djangorestframework, and pika. See [backend/ticket-service/requirements.txt](backend/ticket-service/requirements.txt).
+This repository implements a microservices-based ticketing system composed of:
 
-## Developer workflows (ticket-service)
-- Run Django management commands from backend/ticket-service/ using manage.py. See [backend/ticket-service/manage.py](backend/ticket-service/manage.py).
-- Typical lifecycle when adding models: create migrations and migrate before running the dev server.
+- **Ticket Service** (backend/ticket-service): Gestión de tickets y estados. Referencia DDD.
+- **Assignment Service** (backend/assignment-service): Asignación de tickets a agentes.
+- **Notification Service** (backend/notification-service): Gestión de notificaciones.
+- **User Service** (backend/users-service): Usuarios y autenticación.
+- **Frontend** (frontend/): SPA React + TypeScript.
 
-## Conventions & patterns
-- Keep Django app code under backend/ticket-service/tickets/; project-level config stays in backend/ticket-service/ticket_service/.
-- If adding API endpoints, update project URLs in [backend/ticket-service/ticket_service/urls.py](backend/ticket-service/ticket_service/urls.py) and implement views in [backend/ticket-service/tickets/views.py](backend/ticket-service/tickets/views.py).
-- Messaging-related code should live under backend/ticket-service/messaging/; there are placeholder modules for events and RabbitMQ transport.
+**Stack:** Django 5.x, DRF, RabbitMQ (Pika), PostgreSQL 16, React 19, Vite, Vitest. Testing backend: Pytest.
+
+Ticket Service follows Domain Driven Design (DDD).
+Other services are being progressively aligned to this architecture.
+
+When generating code:
+
+- NEVER couple services via database imports
+- ALWAYS communicate via REST API or domain events
+- Prefer event-driven integration over synchronous coupling
+
+---
+
+## Business Rules (Reglas de Negocio)
+
+### Tickets (Ticket Service)
+- **Estados válidos:** `OPEN`, `IN_PROGRESS`, `CLOSED` (transición: OPEN → IN_PROGRESS → CLOSED)
+- **Regla:** Un ticket en estado `CLOSED` NO puede cambiar de estado → lanzar excepción de dominio `TicketAlreadyClosed`
+- **Creación:** Ticket nuevo siempre inicia en `OPEN`. Título y descripción obligatorios.
+- **Eventos:** Tras crear ticket → publicar `ticket.created`; tras cambio de estado válido → publicar `ticket.status_changed` (ver esquemas abajo)
+- **Idempotencia:** Si el ticket ya tiene el estado solicitado, no hacer cambio ni publicar evento
+
+**Contratos de eventos (mantener compatibilidad):**
+
+`ticket.created`:
+```json
+{ "event_type": "ticket.created", "ticket_id": int, "title": str, "user_id": int, "status": "open", "timestamp": "ISO8601" }
+```
+
+`ticket.status_changed`:
+```json
+{ "event_type": "ticket.status_changed", "ticket_id": int, "old_status": str, "new_status": str, "timestamp": "ISO8601" }
+```
+
+### Asignación (Assignment Service)
+- **Regla:** Al recibir evento `ticket.created`, asignar un agente al ticket
+- **Prioridad:** Actualmente lógica placeholder (aleatoria). Al evolucionar, usar reglas de negocio (carga, SLA, roles) en capa de dominio, no en handler
+
+### Notificaciones (Notification Service)
+- **Regla:** Al recibir `ticket.created` (y otros eventos definidos), crear notificación correspondiente y persistirla
+- **Responsabilidad:** La regla de qué notificar vive en dominio; el handler solo orquesta
+
+### Usuarios (User Service)
+- **Roles:** Usuario estándar vs agente
+- **Comunicación:** Otros servicios NO deben importar modelos de User Service ni acceder a `users_db`. Usar API REST o eventos
+- **Objetivo:** User Service aún no publica eventos; al integrarlo en EDA, emitir eventos ante cambios de usuario/rol
+
+### Referencias de documentación
+- Reglas detalladas y riesgos: [HANDOVER_REPORT.md](HANDOVER_REPORT.md), [AUDITORIA.md](AUDITORIA.md), [DEUDA_TECNICA.md](DEUDA_TECNICA.md), [CALIDAD.md](CALIDAD.md)
+- Arquitectura DDD por servicio: `backend/ticket-service/ARCHITECTURE_DDD.md`
+
+---
+
+# Coding Philosophy
+
+## Type Hints
+- **Ticket Service:** 100% type hints (mantener).
+- **Assignment, Notification, User Services:** Extender type hints en código nuevo. Priorizar dominio y casos de uso.
+- Usar anotaciones en funciones públicas y constructores.
+
+## Clean Architecture Priority
+
+Always respect layer separation:
+
+Domain → Application → Infrastructure → Presentation
+
+Rules:
+
+- Domain must be pure Python (no Django imports)
+- Business logic must NOT exist in Django Views
+- Messaging handlers must delegate to Use Cases
+- ORM models belong ONLY to infrastructure
+
+
+---
+
+# Naming Conventions
+
+## Python
+
+- Classes → PascalCase
+- Functions → snake_case
+- Variables → snake_case
+- Constants → UPPER_CASE
+
+## TypeScript / React
+
+- Components → PascalCase
+- Hooks → camelCase
+- Variables → camelCase
+
+
+---
+
+# Error Handling Rules
+
+## Backend
+
+- Wrap RabbitMQ consumers in try/except
+- Never crash consumer loop
+- Always log structured errors
+
+## Frontend
+
+- Always use global error boundaries
+- Handle API failures explicitly
+- Never silently ignore HTTP errors
+
+
+---
+
+# RabbitMQ Rules
+
+- Events must include: `event_type`, `timestamp`, payload object (ver contratos en Business Rules)
+- Consumers must be idempotent
+- Never assume message delivery exactly once
+- Support reconnection logic
+- **Reducción de duplicación:** ~90% del setup de consumidores se duplica entre Assignment y Notification. Al refactorizar, considerar abstracción común (ej. `BaseRabbitMQConsumer`) para evitar código duplicado
+
+
+---
+
+# Database Rules
+
+STRICT RULE:
+
+❌ NEVER import models from another microservice  
+❌ NEVER connect to another service DB  
+
+✔ Use REST API  
+✔ Use events  
+
+This is mandatory.
+
+
+---
+
+# Testing Standards
+
+Backend:
+
+- Unit tests for domain logic required
+- Avoid Django dependency in domain tests
+
+Frontend:
+
+- Use Vitest + React Testing Library
+- Test behavior, not implementation
+
+
+---
+
+# Security Standards
+
+Frontend:
+
+- Never store auth tokens in localStorage
+- Prefer HttpOnly cookies strategy
+
+Backend:
+
+- Secrets must come from environment variables
+- Never hardcode credentials
+
+
+---
+
+# Documentation Standards
+
+When generating code:
+
+- Add docstrings to public Python functions
+- Add JSDoc for exported TypeScript functions
+- Explain event payload structures
+
+Focus on clarity over verbosity.
+
+---
+
+

--- a/.github/instructions/backend-ddd.instructions.md
+++ b/.github/instructions/backend-ddd.instructions.md
@@ -1,0 +1,61 @@
+# Backend DDD Rules (Django Microservices)
+
+name: Backend DDD Rules
+description: Reglas para microservicios Django (backend)
+applyTo: "backend/**/*.py"
+
+## Mandatory Separation
+
+Never place business logic inside:
+
+- serializers.py
+- views.py
+- messaging handlers
+
+Instead:
+
+View → UseCase → Domain → Repository
+
+
+---
+
+## Repository Pattern Required
+
+All persistence must go through repositories.
+
+Never:
+
+
+Model.objects.create()
+
+
+inside business logic.
+
+
+---
+
+## Domain Rules
+
+Domain layer:
+
+- must not import Django
+- must not import REST framework
+- must not import RabbitMQ
+
+Only pure Python allowed.
+
+
+---
+
+## Messaging Rules
+
+RabbitMQ handlers must:
+
+1. Parse message
+2. Validate schema
+3. Call use case
+4. ACK message
+
+Never implement business decisions inside handler.
+
+---

--- a/.github/instructions/frontend-react.instructions.md
+++ b/.github/instructions/frontend-react.instructions.md
@@ -1,0 +1,52 @@
+
+# React Frontend Rules
+
+---
+name: React Frontend Rules
+description: Reglas para frontend React + TypeScript
+applyTo: "frontend/**/*.{ts,tsx}"
+---
+
+## Component Rules
+
+- Prefer functional components
+- Keep components under 250 lines
+- Move API calls to services/
+
+Never call axios directly inside components.
+
+
+---
+
+## API Rules
+
+Use dedicated API clients:
+
+ticketApi  
+usersApi  
+notificationApi  
+
+Do not create inline fetch calls.
+
+
+---
+
+## State Management
+
+- Prefer Context for global state
+- Keep state local when possible
+- Avoid prop drilling
+
+
+---
+
+## Security Rules
+
+Never:
+
+- store JWT in localStorage
+- expose backend service ports in code
+
+Always rely on environment config.
+
+---

--- a/.github/instructions/rabbitmq.instructions.md
+++ b/.github/instructions/rabbitmq.instructions.md
@@ -1,0 +1,49 @@
+
+# RabbitMQ Consumer Standards
+
+---
+name: RabbitMQ Messaging Rules
+description: Estándares de arquitectura event-driven
+applyTo: "**/messaging/**/*.py"
+---
+
+## Mandatory Consumer Structure
+
+Consumer must:
+
+- auto reconnect on failure
+- validate JSON safely
+- log errors
+- retry transient failures
+
+
+---
+
+## Event Schema Standard
+
+Every event must contain:
+
+- event_type (string)
+- timestamp (ISO)
+- payload object
+
+Reject invalid messages.
+
+
+---
+
+## Idempotency
+
+Consumers must support duplicate messages.
+
+Never assume message processed once.
+
+
+---
+
+## Dead Letter Strategy
+
+If message fails permanently:
+
+- send to DLQ
+- log full payload


### PR DESCRIPTION
## Descripción

Configuración de reglas para GitHub Copilot mediante el archivo `.github/copilot-instructions.md` y módulos de instrucciones específicos en `.github/instructions/`, como parte del Taller Semana 2: Engineering Handover & AI-Augmented Quality.

## Cambios realizados

### Archivo principal
- **`.github/copilot-instructions.md`**: Archivo raíz que guía a Copilot sobre el proyecto heredado (brownfield).

### Contenido implementado
- **Estilo de código**: Convenciones y formato del proyecto.
- **Reglas de negocio**: Dominio de tickets, asignación, notificaciones y usuarios.
- **Patrones arquitectónicos**: DDD, capas, Repository, Use Cases.
- **Seguridad y errores**: Restricciones y manejo de errores.
- **Referencias**: Vinculación a `HANDOVER_REPORT.md`, `AUDITORIA.md`, `CALIDAD.md`, `DEUDA_TECNICA.md`.

### Archivos de instrucciones modulares
- `backend-ddd.instructions.md`: Reglas para backend con arquitectura DDD.
- `frontend-react.instructions.md`: Reglas para frontend en React.
- `rabbitmq.instructions.md`: Reglas para integración con RabbitMQ.

## Criterios de aceptación

- [x] Archivo `.github/copilot-instructions.md` en la raíz del proyecto.
- [x] Documenta estilo de código, reglas de negocio y patrones arquitectónicos.
- [x] Cumple estándares de VS Code para `copilot-instructions.md`.
- [x] Referencias a documentación existente (HANDOVER_REPORT, AUDITORIA, CALIDAD, DEUDA_TECNICA).

Closes #4 