### PR TITLE
feat(ticket-service): validar longitud máxima de justificación de prioridad (BVA7-BVA10)

### DIFF
--- a/backend/ticket-service/tickets/domain/entities.py
+++ b/backend/ticket-service/tickets/domain/entities.py
@@ -203,8 +203,11 @@ class Ticket:
         """
         Valida que la justificación no exceda la longitud máxima permitida.
         
+        Regla: La justificación de cambio de prioridad no puede superar
+        MAX_JUSTIFICATION_LENGTH (255) caracteres.
+        
         Args:
-            justification: Justificación a validar
+            justification: Justificación a validar (None y cadena vacía son válidos)
             
         Raises:
             ValueError: Si la justificación excede MAX_JUSTIFICATION_LENGTH caracteres
@@ -232,17 +235,20 @@ class Ticket:
         3. No se puede volver a Unassigned una vez asignada otra prioridad
         4. El cambio es idempotente (si ya tiene esa prioridad, no hace nada)
         5. Cada cambio válido genera un evento de dominio TicketPriorityChanged
+        6. La justificación no puede exceder 255 caracteres (MAX_JUSTIFICATION_LENGTH)
         
         Args:
             new_priority: Nueva prioridad del ticket (Unassigned, Low, Medium, High).
             justification: Justificación opcional del cambio de prioridad. Se almacena
                           tal como se proporciona y es visible en el detalle del ticket.
                           Puede ser None si el cambio no requiere justificación.
+                          Máximo 255 caracteres.
             
         Raises:
             TicketAlreadyClosed: Si el ticket está cerrado
             InvalidPriorityTransition: Si la transición no es válida
-            ValueError: Si la prioridad no es un valor válido
+            ValueError: Si la prioridad no es un valor válido o si la
+                       justificación excede 255 caracteres
         """
         # Regla: No se puede cambiar la prioridad de un ticket cerrado
         self._ensure_not_closed()

--- a/backend/ticket-service/tickets/tests/unit/test_use_cases.py
+++ b/backend/ticket-service/tickets/tests/unit/test_use_cases.py
@@ -723,10 +723,11 @@ class TestChangeTicketPriorityUseCase:
         BVA7: Justificación vacía (0 caracteres) es aceptada.
 
         Scenario: Justificación vacía es aceptada (BVA7)
-          Given un ticket en estado "Open"
+          Given un ticket en estado "Open" con prioridad "Unassigned"
           And el usuario autenticado tiene rol "Administrador"
           When cambia la prioridad a "High" con justificación de 0 caracteres
-          Then la prioridad se actualiza exitosamente
+          Then la prioridad del ticket se actualiza a "High"
+          And se genera un evento de dominio "TicketPriorityChanged"
         """
         # Arrange
         existing_ticket, use_case, command, mock_repo, mock_publisher = (
@@ -745,19 +746,25 @@ class TestChangeTicketPriorityUseCase:
 
         # Assert
         assert updated_ticket.priority == "High"
+        assert updated_ticket.priority_justification == ""
+        mock_repo.find_by_id.assert_called_once_with(107)
         mock_repo.save.assert_called_once()
         mock_publisher.publish.assert_called_once()
+        event = mock_publisher.publish.call_args[0][0]
+        assert isinstance(event, TicketPriorityChanged)
+        assert event.ticket_id == 107
 
     @pytest.mark.parametrize("length", [254, 255])
     def test_justification_within_limit_is_accepted_bva8_bva9(self, length: int):
         """
         BVA8/BVA9: Justificación de 254 y 255 caracteres es aceptada.
 
-        Scenario: Justificación dentro del límite es aceptada (BVA8/BVA9)
-          Given un ticket en estado "Open"
+        Scenario Outline: Justificación dentro del límite es aceptada (BVA8/BVA9)
+          Given un ticket en estado "Open" con prioridad "Unassigned"
           And el usuario autenticado tiene rol "Administrador"
           When cambia la prioridad a "Medium" con una justificación de <length> caracteres
-          Then la prioridad se actualiza exitosamente
+          Then la prioridad del ticket se actualiza a "Medium"
+          And se genera un evento de dominio "TicketPriorityChanged"
         """
         # Arrange
         existing_ticket, use_case, command, mock_repo, mock_publisher = (
@@ -777,19 +784,26 @@ class TestChangeTicketPriorityUseCase:
         # Assert
         assert updated_ticket.priority == "Medium"
         assert len(updated_ticket.priority_justification) == length
+        mock_repo.find_by_id.assert_called_once_with(108)
         mock_repo.save.assert_called_once()
         mock_publisher.publish.assert_called_once()
+        event = mock_publisher.publish.call_args[0][0]
+        assert isinstance(event, TicketPriorityChanged)
+        assert event.ticket_id == 108
 
     def test_justification_exceeding_max_length_is_rejected_bva10(self):
         """
         BVA10: Justificación que excede 255 caracteres es rechazada.
 
         Scenario: Justificación que excede el límite de caracteres es rechazada (BVA10)
-          Given un ticket en estado "Open"
+          Given un ticket en estado "Open" con prioridad "Unassigned"
           And el usuario autenticado tiene rol "Administrador"
           When intenta cambiar la prioridad a "Medium" con una justificación de 256 caracteres
           Then el sistema rechaza la acción
           And se informa que la justificación excede la longitud máxima
+          And la prioridad del ticket permanece en "Unassigned"
+          And no se persiste ningún cambio
+          And no se publica ningún evento de dominio
         """
         # Arrange
         existing_ticket, use_case, command, mock_repo, mock_publisher = (
@@ -806,6 +820,12 @@ class TestChangeTicketPriorityUseCase:
         # Act & Assert
         with pytest.raises(ValueError, match="justificación.*longitud máxima"):
             use_case.execute(command)
+
+        # La prioridad debe permanecer sin cambios
+        assert existing_ticket.priority == "Unassigned"
+
+        # Assert — repository looked up by correct ID
+        mock_repo.find_by_id.assert_called_once_with(110)
 
         # No debe persistir ni publicar eventos
         mock_repo.save.assert_not_called()


### PR DESCRIPTION
## Descripción

Implementa la validación de longitud máxima (255 caracteres) para la justificación de cambio de prioridad en la entidad de dominio `Ticket` del `ticket-service`.

## Issue relacionado

Closes #43

## Escenarios cubiertos (TEST_PLAN2.md)

| Caso | Longitud | Resultado esperado | Estado |
|------|----------|-------------------|--------|
| BVA7 | 0 caracteres (vacío) | Válido |  |
| BVA8 | 254 caracteres | Válido |  |
| BVA9 | 255 caracteres (en el límite) | Válido |  |
| BVA10 | 256 caracteres (sobre el límite) | Rechazado |  |

## Ciclo TDD aplicado

###  RED
- Se agregaron 4 tests (3 métodos, 1 parametrizado) en `test_use_cases.py`
- BVA10 falló con `DID NOT RAISE ValueError` (validación no existía)
- Commit: `test(ticket-service): RED  add failing tests for justification length BVA7-BVA10 #43`

###  GREEN
- Se agregó `MAX_JUSTIFICATION_LENGTH = 255` y `_validate_justification_length()` a `Ticket`
- Se invoca en `change_priority()` antes de cambios de estado
- 32/32 tests pasan
- Commit: `feat(ticket-service): GREEN  add justification length validation (max 255 chars) #43`

###  REFACTOR
- Mejora de docstrings en `change_priority()` (regla 6 documentada)
- Mejora de docstrings en `_validate_justification_length()`
- Mejora de aserciones y Gherkin en tests BVA
- 32/32 tests siguen pasando
- Commit: `refactor(ticket-service): REFACTOR  improve docstrings and test consistency for BVA7-BVA10 #43`

## Cambios realizados

- `backend/ticket-service/tickets/domain/entities.py`: Constante `MAX_JUSTIFICATION_LENGTH`, método `_validate_justification_length()`, llamada en `change_priority()`
- `backend/ticket-service/tickets/tests/unit/test_use_cases.py`: 4 tests BVA (3 métodos)

## Verificación

- [x] Todos los tests pasan (32/32)
- [x] Sin dependencias de Django (dominio puro)
- [x] Sin cambios de comportamiento en tests existentes
- [x] Commits atómicos por fase TDD