### PR TITLE
feat(ticket-service): mapear campos priority en DjangoTicketRepository

### DIFF
--- a/backend/ticket-service/tickets/infrastructure/repository.py
+++ b/backend/ticket-service/tickets/infrastructure/repository.py
@@ -19,6 +19,7 @@ class DjangoTicketRepository(TicketRepository):
     def save(self, ticket: DomainTicket) -> DomainTicket:
         """
         Persiste un ticket en la base de datos (crear o actualizar).
+        Mapea todos los campos incluyendo priority y priority_justification.
         
         Args:
             ticket: Entidad de dominio
@@ -35,7 +36,11 @@ class DjangoTicketRepository(TicketRepository):
             django_ticket.user_id = ticket.user_id
             django_ticket.priority = ticket.priority
             django_ticket.priority_justification = ticket.priority_justification
-            django_ticket.save(update_fields=['title', 'description', 'status', 'user_id', 'priority', 'priority_justification'])
+            # Actualizar solo campos del dominio (excluye created_at)
+            django_ticket.save(update_fields=[
+                'title', 'description', 'status', 'user_id',
+                'priority', 'priority_justification',
+            ])
         else:
             # Crear nuevo ticket
             django_ticket = DjangoTicket.objects.create(
@@ -89,6 +94,7 @@ class DjangoTicketRepository(TicketRepository):
         """
         Convierte una entidad de dominio a modelo Django sin hacer query adicional.
         Útil para serialización en la capa de presentación.
+        Incluye mapeo de priority y priority_justification.
         
         Args:
             domain_ticket: Entidad de dominio
@@ -127,6 +133,7 @@ class DjangoTicketRepository(TicketRepository):
     def _to_domain(django_ticket: DjangoTicket) -> DomainTicket:
         """
         Convierte un modelo Django a entidad de dominio.
+        Mapea todos los campos persistidos, incluyendo priority y priority_justification.
         
         Args:
             django_ticket: Modelo Django

--- a/backend/ticket-service/tickets/tests/integration/test_ticket_repository.py
+++ b/backend/ticket-service/tickets/tests/integration/test_ticket_repository.py
@@ -375,7 +375,7 @@ class TestDjangoTicketRepositoryIntegration(TestCase):
         assert ticket2.status == "OPEN"
         assert ticket1.status == "IN_PROGRESS"
 
-    # ========== Phase 2: Repository Priority Mapping (RED) ==========
+    # ==================== Priority Mapping Tests ====================
 
     def test_save_and_retrieve_preserves_priority(self):
         """Round-trip: guardar ticket con priority y recuperarlo preserva el valor."""

--- a/backend/ticket-service/tickets/tests/unit/test_infrastructure.py
+++ b/backend/ticket-service/tickets/tests/unit/test_infrastructure.py
@@ -129,7 +129,7 @@ class TestDjangoTicketRepository(TestCase):
         # No debe lanzar excepción
         self.repository.delete(999999)
 
-    # ========== Phase 2: Repository Priority Mapping (RED) ==========
+    # ==================== Priority Mapping Tests ====================
 
     def test_save_new_ticket_persists_priority(self):
         """save() persiste priority al crear un ticket nuevo."""


### PR DESCRIPTION
## Descripción

Actualiza `DjangoTicketRepository` para mapear los campos `priority` y `priority_justification` en todas las operaciones de persistencia y conversión. Sin este cambio, los cambios de prioridad realizados en la capa de dominio no se persistían ni recuperaban de la base de datos.

## Cambios realizados

### Repositorio (`tickets/infrastructure/repository.py`)
- **`save()` — creación:** agrega `priority` y `priority_justification` a `DjangoTicket.objects.create()`
- **`save()` — actualización:** agrega campos a `update_fields` y mapeo de atributos
- **`_to_domain()`:** mapea `priority` y `priority_justification` de Django a `DomainTicket`
- **`to_django_model()` con ID:** mapea `priority` y `priority_justification` desde entidad de dominio
- **`to_django_model()` sin ID:** incluye ambos campos en constructor de `DjangoTicket` en memoria
- Docstrings actualizados mencionando mapeo de prioridad, `update_fields` reformateado

### Tests unitarios (`tickets/tests/unit/test_infrastructure.py`)
8 nuevos tests en `TestDjangoTicketRepository`:
- `test_save_new_ticket_persists_priority` (RED-2.1)
- `test_save_new_ticket_persists_priority_justification` (RED-2.2)
- `test_save_existing_ticket_updates_priority` (RED-2.3)
- `test_save_existing_ticket_updates_priority_justification` (RED-2.4)
- `test_find_by_id_maps_priority_to_domain` (RED-2.5)
- `test_find_by_id_maps_priority_justification_to_domain` (RED-2.6)
- `test_to_django_model_maps_priority_from_domain` (RED-2.7)
- `test_to_django_model_without_id_maps_priority` (RED-2.8)

### Tests de integración (`tickets/tests/integration/test_ticket_repository.py`)
2 nuevos tests en `TestDjangoTicketRepositoryIntegration`:
- `test_save_and_retrieve_preserves_priority` (RED-2.9)
- `test_save_and_retrieve_preserves_priority_justification` (RED-2.10)

## Ciclo TDD aplicado

| Fase | Commit | Detalle |
|------|--------|---------|
| 🔴 RED | `8dff0d6` | 10 tests que fallan — repositorio no mapea campos de prioridad |
| 🟢 GREEN | `154328c` | 5 puntos de cambio en repository.py — 10/10 tests pasan |
| 🔵 REFACTOR | `0210e5a` | Docstrings, separadores, legibilidad — tests siguen verdes |

## Issue relacionado

Closes #62

## Referencias
- [TDD_TEST_SCENARIOS_PRIORITY.md](TDD_TEST_SCENARIOS_PRIORITY.md) — Fase 2, ciclos RED-2.1 a RED-2.10
- [PRIORITY_IMPLEMENTATION_GAP.md](PRIORITY_IMPLEMENTATION_GAP.md) — Sección 3.2
- [USER_STORY_TICKET_PRIORITY.md](user-stories/USER_STORY_TICKET_PRIORITY.md) — Capacidades C1, C2, C6