### PR TITLE
feat(ticket-service): Serializer — exponer campos de prioridad como read-only (Fase 4 TDD)

### DIFF
--- a/backend/ticket-service/tickets/serializer.py
+++ b/backend/ticket-service/tickets/serializer.py
@@ -14,8 +14,13 @@ class TicketSerializer(serializers.ModelSerializer):
 
     Convierte instancias de :class:`~tickets.models.Ticket` a/desde
     representaciones JSON. Expone **todos** los campos del modelo:
-    ``id``, ``title``, ``description``, ``status``, ``user_id`` y
-    ``created_at``.
+    ``id``, ``title``, ``description``, ``status``, ``user_id``,
+    ``created_at``, ``priority`` y ``priority_justification``.
+
+    Los campos ``priority`` y ``priority_justification`` son de **solo
+    lectura**: se incluyen en las respuestas pero se ignoran en
+    operaciones de creación/actualización convencionales.  Solo pueden
+    modificarse a través del endpoint dedicado de priorización.
 
     Note:
         Utiliza ``fields = "__all__"`` para exponer la totalidad de los

--- a/backend/ticket-service/tickets/tests/unit/test_views.py
+++ b/backend/ticket-service/tickets/tests/unit/test_views.py
@@ -167,11 +167,11 @@ class TestTicketViewSet(TestCase):
 
 
 class TestTicketSerializer(TestCase):
-    """Tests del serializer (sin cambios desde refactor)."""
+    """Tests del TicketSerializer: validación de campos requeridos e integración de priority."""
     
     def test_serializer_accepts_valid_data(self):
         """Serializer acepta datos válidos."""
-        data = {"title": "Test", "description": "Description"}
+        data = {"title": "Test", "description": "Description", "user_id": "1"}
         serializer = TicketSerializer(data=data)
         
         assert serializer.is_valid()


### PR DESCRIPTION
## Descripción

Implementa la **Fase 4** del plan TDD definido en `TDD_TEST_SCENARIOS_PRIORITY.md`: tests y cambios en el `TicketSerializer` para exponer los campos `priority` y `priority_justification` como **read-only**.

### Problema

El `TicketSerializer` usaba `fields = "__all__"` sin restricciones, lo que permitía que un usuario estableciera la prioridad al crear un ticket vía `POST /api/tickets/`. Esto viola la regla de negocio: la prioridad solo debe ser modificada por administradores a través del endpoint dedicado.

### Solución

- Agregar `read_only_fields = ("priority", "priority_justification")` al `Meta` del serializer
- Los campos se incluyen en respuestas GET (necesario para HU-1.2 y HU-1.5)
- Los campos son ignorados en POST de creación

## Ciclo TDD aplicado

| Fase | Commit | Detalle |
|------|--------|---------|
| 🔴 **RED** | `cf6235f` | 4 tests: RED-4.1 (priority en response), RED-4.2 (justification en response), RED-4.3 (priority ignorado en POST), RED-4.4 (justification ignorado en POST). RED-4.3 y RED-4.4 fallan porque no hay `read_only_fields` |
| 🟢 **GREEN** | `ef45e97` | Agregar `read_only_fields = ("priority", "priority_justification")` — cambio mínimo, 1 línea |
| 🔵 **REFACTOR** | `ac51e5f` | Actualizar docstrings del serializer y tests. Corregir test preexistente `test_serializer_accepts_valid_data` que fallaba por falta de `user_id` |

## Tests

- **8/8 tests pasan** en `TestTicketSerializer`
- Cobertura: exposición de campos en GET + protección read-only en POST

## Archivos modificados

- `backend/ticket-service/tickets/serializer.py` — `read_only_fields` + docstring actualizada
- `backend/ticket-service/tickets/tests/unit/test_views.py` — 4 nuevos tests + fix test preexistente

## Referencias

- Closes #66
- [TDD_TEST_SCENARIOS_PRIORITY.md](TDD_TEST_SCENARIOS_PRIORITY.md) — Fase 4
- [PRIORITY_IMPLEMENTATION_GAP.md](PRIORITY_IMPLEMENTATION_GAP.md) — Sección 4.1
- [user-stories/USER_STORY_TICKET_PRIORITY.md](user-stories/USER_STORY_TICKET_PRIORITY.md) — HU-1.2, HU-1.5