### PR TITLE
feat(ticket-service): implementar endpoint PATCH /api/tickets/{id}/priority/

### DIFF
--- a/backend/ticket-service/tickets/tests/unit/test_views.py
+++ b/backend/ticket-service/tickets/tests/unit/test_views.py
@@ -5,6 +5,8 @@ Prueban la integración HTTP con casos de uso.
 
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
+from rest_framework.request import Request
+from rest_framework.parsers import JSONParser, FormParser, MultiPartParser
 from rest_framework import status
 from unittest.mock import Mock, patch
 
@@ -22,6 +24,10 @@ class TestTicketViewSet(TestCase):
     def setUp(self):
         """Configurar para cada test."""
         self.factory = APIRequestFactory()
+
+    def _make_drf_request(self, wsgi_request):
+        """Envuelve un WSGIRequest en un DRF Request para llamadas directas a métodos del ViewSet."""
+        return Request(wsgi_request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
     
     def test_viewset_uses_create_use_case_on_create(self):
         """ViewSet ejecuta CreateTicketUseCase al crear ticket."""
@@ -190,7 +196,7 @@ class TestTicketViewSet(TestCase):
         mock_use_case.execute.return_value = mock_domain_ticket
         viewset.change_priority_use_case = mock_use_case
 
-        request = self.factory.patch('', {"priority": "High", "user_role": "Administrador"})
+        request = self._make_drf_request(self.factory.patch('', {"priority": "High", "user_role": "Administrador"}))
 
         response = viewset.change_priority(request, pk=django_ticket.id)
 
@@ -207,7 +213,7 @@ class TestTicketViewSet(TestCase):
 
         viewset = TicketViewSet()
 
-        request = self.factory.patch('', {})
+        request = self._make_drf_request(self.factory.patch('', {}))
 
         response = viewset.change_priority(request, pk=django_ticket.id)
 
@@ -228,7 +234,7 @@ class TestTicketViewSet(TestCase):
         mock_use_case.execute.side_effect = TicketAlreadyClosed(django_ticket.id)
         viewset.change_priority_use_case = mock_use_case
 
-        request = self.factory.patch('', {"priority": "High", "user_role": "Administrador"})
+        request = self._make_drf_request(self.factory.patch('', {"priority": "High", "user_role": "Administrador"}))
 
         response = viewset.change_priority(request, pk=django_ticket.id)
 
@@ -251,7 +257,7 @@ class TestTicketViewSet(TestCase):
         )
         viewset.change_priority_use_case = mock_use_case
 
-        request = self.factory.patch('', {"priority": "Unassigned", "user_role": "Administrador"})
+        request = self._make_drf_request(self.factory.patch('', {"priority": "Unassigned", "user_role": "Administrador"}))
 
         response = viewset.change_priority(request, pk=django_ticket.id)
 
@@ -271,7 +277,7 @@ class TestTicketViewSet(TestCase):
         mock_use_case.execute.side_effect = DomainException("Permiso insuficiente")
         viewset.change_priority_use_case = mock_use_case
 
-        request = self.factory.patch('', {"priority": "High", "user_role": "Usuario"})
+        request = self._make_drf_request(self.factory.patch('', {"priority": "High", "user_role": "Usuario"}))
 
         response = viewset.change_priority(request, pk=django_ticket.id)
 
@@ -301,11 +307,11 @@ class TestTicketViewSet(TestCase):
         mock_use_case.execute.return_value = mock_domain_ticket
         viewset.change_priority_use_case = mock_use_case
 
-        request = self.factory.patch('', {
+        request = self._make_drf_request(self.factory.patch('', {
             "priority": "High",
             "justification": "Urgente",
             "user_role": "Administrador"
-        })
+        }))
 
         response = viewset.change_priority(request, pk=django_ticket.id)
 
@@ -338,7 +344,7 @@ class TestTicketViewSet(TestCase):
         mock_use_case.execute.return_value = mock_domain_ticket
         viewset.change_priority_use_case = mock_use_case
 
-        request = self.factory.patch('', {"priority": "High", "user_role": "Administrador"})
+        request = self._make_drf_request(self.factory.patch('', {"priority": "High", "user_role": "Administrador"}))
 
         response = viewset.change_priority(request, pk=django_ticket.id)
 


### PR DESCRIPTION
## Descripción

Implementa el endpoint `PATCH /api/tickets/{id}/priority/` en `TicketViewSet` para permitir que los administradores cambien la prioridad de un ticket. Este es el último eslabón de la cadena que conecta la lógica de dominio (ya implementada) con la API HTTP.

Corresponde a la **Fase 5 — ViewSet / Endpoint** del plan de implementación de prioridad definido en `TDD_TEST_SCENARIOS_PRIORITY.md`.

Closes #67

## Cambios realizados

### Archivos modificados

| Archivo | Tipo | Descripción |
|---------|------|-------------|
| `tickets/views.py` | Producción | Nuevo endpoint `change_priority` + imports + inicialización del use case |
| `tickets/tests/unit/test_views.py` | Tests | 7 tests nuevos (RED-5.1 a RED-5.7) + helper `_make_drf_request()` |

### Nuevo endpoint

```
PATCH /api/tickets/{id}/priority/
Body: { "priority": "High", "justification": "Motivo opcional", "user_role": "Administrador" }
```

### Respuestas HTTP

| Código | Situación |
|--------|-----------|
| 200 | Prioridad cambiada exitosamente |
| 400 | Campo `priority` faltante, ticket cerrado, o transición de prioridad inválida |
| 403 | Usuario sin rol Administrador |

## TDD aplicado

| Fase | Commit | Descripción |
|------|--------|-------------|
| 🔴 RED | `8a96b4b` | 7 tests que fallan con `AttributeError: no attribute 'change_priority'` |
| 🟢 GREEN | `c95f9be` | Implementación mínima del endpoint — todos los tests pasan |
| 🔵 REFACTOR | `a677f25` | Docstring, consolidación de excepciones, defaults `None`, helper de test |

## Tests

- ✅ 7/7 tests de `change_priority` pasan
- ✅ 41/41 tests de dominio existentes (`test_use_cases.py`) siguen pasando
- ✅ Sin regresiones en tests existentes

## Escenarios cubiertos (RED-5.1 a RED-5.7)

1. Endpoint ejecuta `ChangeTicketPriorityUseCase` correctamente
2. Valida que el campo `priority` es requerido
3. Maneja `TicketAlreadyClosed` → 400
4. Maneja `InvalidPriorityTransition` → 400
5. Maneja permiso insuficiente → 403
6. Pasa justificación opcional al comando
7. Respuesta incluye prioridad actualizada

## Riesgo mitigado

Sin este endpoint, la lógica de dominio y aplicación para gestión de prioridad (completa desde Fase 1-4) era **inaccesible** desde la API REST. Este PR cierra esa brecha y habilita la integración con el frontend.
