### PR TITLE
fix: associate labels with inputs via htmlFor/id in TicketForm

### DIFF
--- a/frontend/src/pages/tickets/TicketForm.tsx
+++ b/frontend/src/pages/tickets/TicketForm.tsx
@@ -22,8 +22,9 @@ const TicketForm = ({ onSubmit }: Props) => {
   return (
     <form onSubmit={handleSubmit} className="ticket-form">
       <div className="form-group">
-      <label className="form-label">Título</label>
+      <label className="form-label" htmlFor="ticket-title">Título</label>
       <input
+        id="ticket-title"
         type="text"
         className="form-input"
         value={title}
@@ -33,8 +34,9 @@ const TicketForm = ({ onSubmit }: Props) => {
       </div>
 
       <div className="form-group">
-      <label className="form-label">Descripción</label>
+      <label className="form-label" htmlFor="ticket-description">Descripción</label>
       <textarea
+        id="ticket-description"
         className="form-textarea"
         value={description}
         onChange={(e) => setDescription(e.target.value)}


### PR DESCRIPTION
## Descripción

Se corrige la asociación entre labels e inputs en el formulario de creación de ticket (`TicketForm.tsx`) para cumplir con estándares de accesibilidad.

## Problema

Los `<label>` del formulario no tenían atributo `htmlFor` y los `<input>`/`<textarea>` no tenían atributo `id`. Esto impedía que:
- Lectores de pantalla vincularan labels con sus campos correspondientes
- Hacer clic en el texto del label enfocara el input asociado

## Cambios realizados

En `frontend/src/pages/tickets/TicketForm.tsx`:
- Agregado `htmlFor="ticket-title"` al label de "Título" e `id="ticket-title"` al input
- Agregado `htmlFor="ticket-description"` al label de "Descripción" e `id="ticket-description"` al textarea

## Issue relacionado

Closes #96

## Verificación

- Sin errores de TypeScript
- Labels ahora están correctamente asociados a sus inputs mediante htmlFor/id