### PR TITLE
fix(security): securizar configuración DJANGO_DEBUG y DRF en producción (BUG-021)

### DIFF
--- a/.env
+++ b/.env
@@ -13,8 +13,14 @@ RABBITMQ_QUEUE_ASSIGNMENT=assignment_queue
 RABBITMQ_QUEUE_NOTIFICATION=notification_queue
 RABBITMQ_QUEUE_USERS=users_queue
 
-# Shared debug flag
+# Shared debug flag (NEVER set to true in production)
 DJANGO_DEBUG=true
+
+# ──────────────────────────────────────────────────────────────
+# PRODUCTION: Override this value in your deployment environment
+#   DJANGO_DEBUG=false
+#   DJANGO_ALLOWED_HOSTS=your-domain.com
+# ──────────────────────────────────────────────────────────────
 
 # Database Configuration - Ticket Service
 TICKET_DB_NAME=sistema_tickets

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# =============================================================================
+# Environment Configuration Template
+# Copy to .env and fill in actual values
+# =============================================================================
+
+# Django secret keys (MUST be unique per service in production)
+TICKET_SERVICE_SECRET_KEY=change-me-in-production
+NOTIFICATION_SERVICE_SECRET_KEY=change-me-in-production
+ASSIGNMENT_SERVICE_SECRET_KEY=change-me-in-production
+USER_SERVICE_SECRET_KEY=change-me-in-production
+
+# RabbitMQ Configuration (shared across services)
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_EXCHANGE_NAME=ticket_events
+
+# Queue Names (one per service)
+RABBITMQ_QUEUE_ASSIGNMENT=assignment_queue
+RABBITMQ_QUEUE_NOTIFICATION=notification_queue
+RABBITMQ_QUEUE_USERS=users_queue
+
+# Debug flag — MUST be false in production
+# Accepts: true | false (case-insensitive)
+DJANGO_DEBUG=false
+
+# Comma-separated list of allowed hosts (required when DEBUG=false)
+DJANGO_ALLOWED_HOSTS=your-domain.com
+
+# Database Configuration - Ticket Service
+TICKET_DB_NAME=sistema_tickets
+TICKET_DB_USER=postgres
+TICKET_DB_PASSWORD=CHANGE_ME
+TICKET_DB_HOST=db
+TICKET_DB_PORT=5432
+
+# Database Configuration - Assignment Service
+ASSIGNMENT_DB_NAME=assessment_db
+ASSIGNMENT_DB_USER=assessment_user
+ASSIGNMENT_DB_PASSWORD=CHANGE_ME
+ASSIGNMENT_DB_HOST=assessment-db
+ASSIGNMENT_DB_PORT=5432
+
+# Database Configuration - Notification Service
+NOTIFICATION_DB_NAME=notifications_db
+NOTIFICATION_DB_USER=notification_user
+NOTIFICATION_DB_PASSWORD=CHANGE_ME
+NOTIFICATION_DB_HOST=notification-db
+NOTIFICATION_DB_PORT=5432
+
+# CORS Configuration
+CORS_ALLOWED_ORIGINS=https://your-domain.com

--- a/backend/assignment-service/assessment_service/settings.py
+++ b/backend/assignment-service/assessment_service/settings.py
@@ -30,9 +30,10 @@ if not SECRET_KEY:
     raise RuntimeError("ASSIGNMENT_SERVICE_SECRET_KEY is not set")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DJANGO_DEBUG", "true").lower() == "true"
+DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() == "true"
 
-ALLOWED_HOSTS = []
+_allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "")
+ALLOWED_HOSTS = [host.strip() for host in _allowed_hosts.split(",") if host.strip()]
 
 
 # Application definition
@@ -167,9 +168,25 @@ REST_FRAMEWORK = {
     ),
 }
 
+# Disable Browsable API in production (security: prevents endpoint/model exposure)
+if not DEBUG:
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = (
+        'rest_framework.renderers.JSONRenderer',
+    )
+
 SIMPLE_JWT = {
     'SIGNING_KEY': os.environ.get('JWT_SECRET_KEY', SECRET_KEY),
     'ALGORITHM': 'HS256',
     'USER_ID_CLAIM': 'user_id',
     'AUTH_HEADER_TYPES': ('Bearer',),
 }
+
+# =============================================================================
+# Security hardening (production)
+# =============================================================================
+if not DEBUG:
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = "DENY"
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = True

--- a/backend/notification-service/notification_service/settings.py
+++ b/backend/notification-service/notification_service/settings.py
@@ -11,7 +11,7 @@ SECRET_KEY = os.getenv("NOTIFICATION_SERVICE_SECRET_KEY")
 if not SECRET_KEY:
     raise RuntimeError("NOTIFICATION_SERVICE_SECRET_KEY is not set")
 
-DEBUG = os.getenv("DJANGO_DEBUG", "true").lower() == "true"
+DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() == "true"
 
 _allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = [host.strip() for host in _allowed_hosts.split(",") if host.strip()] or ["localhost", "127.0.0.1"]
@@ -90,6 +90,12 @@ REST_FRAMEWORK = {
     ),
 }
 
+# Disable Browsable API in production (security: prevents endpoint/model exposure)
+if not DEBUG:
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = (
+        'rest_framework.renderers.JSONRenderer',
+    )
+
 SIMPLE_JWT = {
     'SIGNING_KEY': os.environ.get('JWT_SECRET_KEY', SECRET_KEY),
     'ALGORITHM': 'HS256',
@@ -115,4 +121,14 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
     "x-user-id",
     "x-user-role",
 ]
+
+# =============================================================================
+# Security hardening (production)
+# =============================================================================
+if not DEBUG:
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = "DENY"
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = True
 

--- a/backend/ticket-service/ticket_service/settings.py
+++ b/backend/ticket-service/ticket_service/settings.py
@@ -31,7 +31,7 @@ if not SECRET_KEY:
     raise RuntimeError("TICKET_SERVICE_SECRET_KEY is not set")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DJANGO_DEBUG", "true").lower() == "true"
+DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() == "true"
 
 _allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = [host.strip() for host in _allowed_hosts.split(",") if host.strip()]
@@ -62,6 +62,12 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ),
 }
+
+# Disable Browsable API in production (security: prevents endpoint/model exposure)
+if not DEBUG:
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = (
+        'rest_framework.renderers.JSONRenderer',
+    )
 
 SIMPLE_JWT = {
     'SIGNING_KEY': os.environ.get('JWT_SECRET_KEY', SECRET_KEY),
@@ -171,3 +177,13 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
     "x-user-id",
     "x-user-role",
 ]
+
+# =============================================================================
+# Security hardening (production)
+# =============================================================================
+if not DEBUG:
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = "DENY"
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = True

--- a/backend/users-service/user_service/settings.py
+++ b/backend/users-service/user_service/settings.py
@@ -27,7 +27,7 @@ if not SECRET_KEY:
     raise RuntimeError("USER_SERVICE_SECRET_KEY is not set")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DJANGO_DEBUG", "true").lower() == "true"
+DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() == "true"
 
 _allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = [host.strip() for host in _allowed_hosts.split(",") if host.strip()]
@@ -161,6 +161,12 @@ REST_FRAMEWORK = {
     ),
 }
 
+# Disable Browsable API in production (security: prevents endpoint/model exposure)
+if not DEBUG:
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = (
+        'rest_framework.renderers.JSONRenderer',
+    )
+
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
@@ -190,3 +196,13 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
     "x-user-id",
     "x-user-role",
 ]
+
+# =============================================================================
+# Security hardening (production)
+# =============================================================================
+if not DEBUG:
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = "DENY"
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
## Bug Resuelto

**BUG-021** — `DJANGO_DEBUG=true` en entorno de producción

### Vulnerabilidades Corregidas

| Vulnerabilidad | Nivel de Riesgo | Estado |
|---|---|---|
| DEBUG=true exponiendo stack traces y SQL | **CRÍTICO** | ✅ Corregido |
| BrowsableAPIRenderer exponiendo endpoints | **ALTO** | ✅ Corregido |
| Default de DEBUG era `true` si falta la env var | **ALTO** | ✅ Corregido |
| ALLOWED_HOSTS vacío en assignment-service | **MEDIO** | ✅ Corregido |
| Sin headers de seguridad en producción | **MEDIO** | ✅ Corregido |

### Cambios Realizados

#### 1. Configuración de Entorno
- `.env`: Documentación de producción añadida
- `.env.example`: Nuevo archivo con defaults seguros (`DJANGO_DEBUG=false`)

#### 2. Los 4 servicios backend (`settings.py`)
- **DEBUG default**: `"true"` → `"false"` (fail-safe: si falta la variable, producción es segura)
- **ALLOWED_HOSTS**: assignment-service ahora usa patrón `os.getenv` como los demás
- **DRF Renderers**: `BrowsableAPIRenderer` deshabilitado cuando `DEBUG=False`
- **Security hardening**: Headers de seguridad activados en producción

#### 3. Principio 12-Factor App
- Configuración por entorno vía variables de entorno
- Defaults seguros (producción) — requiere opt-in explícito para modo debug
- Separación clara desarrollo/producción sin archivos de settings separados

### Validación

**En desarrollo** (`DJANGO_DEBUG=true` en .env):
- DEBUG activo, BrowsableAPI disponible, sin headers restrictivos
- Comportamiento idéntico al anterior

**En producción** (`DJANGO_DEBUG=false` o variable ausente):
- DEBUG desactivado, solo JSONRenderer, headers de seguridad activos
- Stack traces y SQL queries NO se exponen

### Servicios Afectados
- ticket-service
- users-service
- assignment-service
- notification-service

Closes #BUG-021