### PR TITLE
feat(frontend): alinear UI de la pestaña Asignaciones con la pestaña Tickets

### DIFF
--- a/frontend/src/pages/assignments/AssignmentList.css
+++ b/frontend/src/pages/assignments/AssignmentList.css
@@ -61,12 +61,35 @@
   box-shadow: 0 4px 10px rgba(148, 163, 184, 0.3);
 }
 
+/* Header del ticket dentro de la tarjeta: badge #id + título */
+.assignment-ticket-header {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0.5rem 0 1rem 0;
+}
+
+.assignment-ticket-id {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #6366f1 0%, #3b82f6 100%);
+  color: #ffffff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: 50px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 .assignment-title {
   color: #1e293b;
   font-size: 1.15rem;
   font-weight: 600;
-  margin: 0.5rem 0 1rem 0;
+  margin: 0;
   line-height: 1.3;
+  flex: 1;
 }
 
 .assignment-message {

--- a/frontend/src/pages/assignments/AssignmentList.tsx
+++ b/frontend/src/pages/assignments/AssignmentList.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react';
 import { assignmentsApi } from '../../services/assignment';
 import { ticketApi } from '../../services/ticketApi';
+import { userService } from '../../services/user';
 import { LoadingState, EmptyState, PageHeader } from '../../components/common';
 import type { Assignment } from '../../types/assignment';
+import type { TicketPriority } from '../../types/ticket';
+import { formatPriority } from '../tickets/priorityUtils';
 import TicketAssign from '../../components/TicketAssign';
 import ConfirmModal from '../../components/ConfirmModal';
 import './AssignmentList.css';
@@ -13,22 +16,47 @@ import './AssignmentList.css';
 interface UIAssignment extends Assignment {
   managing?: boolean;
   completed?: boolean;
+  /** Título del ticket asociado, resuelto en tiempo de carga. */
+  ticket_title?: string;
+}
+
+/**
+ * Normaliza un string de prioridad arbitrario al tipo {@link TicketPriority}.
+ * Acepta cualquier casing ('HIGH', 'high', 'High' → 'High').
+ *
+ * @param raw - Valor de prioridad crudo proveniente de la API
+ * @returns Valor normalizado compatible con {@link TicketPriority}
+ */
+function toPriorityKey(raw: string | undefined): TicketPriority {
+  if (!raw) return 'Unassigned';
+  const normalized = (raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase()) as TicketPriority;
+  const valid: TicketPriority[] = ['Unassigned', 'Low', 'Medium', 'High'];
+  return valid.includes(normalized) ? normalized : 'Unassigned';
 }
 
 const AssignmentList = () => {
   const [assignments, setAssignments] = useState<UIAssignment[]>([]);
+  const [agentMap, setAgentMap] = useState<Map<string, string>>(new Map());
   const [loading, setLoading] = useState(true);
   const [deleteId, setDeleteId] = useState<number | null>(null);
 
   const loadAssignments = async () => {
     try {
       setLoading(true);
-      
-      // Fetch both assignments and active tickets concurrently
-      const [assignmentsData, ticketsData] = await Promise.all([
+
+      // Fetch assignments, tickets y agentes concurrentemente
+      const [assignmentsData, ticketsData, adminUsers] = await Promise.all([
         assignmentsApi.getAssignments(),
-        ticketApi.getTickets()
+        ticketApi.getTickets(),
+        userService.getAdminUsers().catch(() => []),
       ]);
+
+      // Mapa de id → título de ticket para enriquecer las tarjetas
+      const ticketTitleMap = new Map(ticketsData.map(t => [t.id.toString(), t.title]));
+
+      // Mapa de id → username de agente para resolver nombre en descripción
+      const newAgentMap = new Map(adminUsers.map(u => [u.id, u.username]));
+      setAgentMap(newAgentMap);
 
       // Filter out assignments for tickets that don't exist anymore
       const activeTicketIds = new Set(ticketsData.map(t => t.id.toString()));
@@ -46,6 +74,7 @@ const AssignmentList = () => {
           ...a,
           managing: false,
           completed: closedTicketIds.has(a.ticket_id.toString()),
+          ticket_title: ticketTitleMap.get(a.ticket_id.toString()),
         }))
       );
     } catch (error) {
@@ -159,13 +188,20 @@ const AssignmentList = () => {
               className={`assignment-card ${item.completed ? 'completed' : ''}`}
             >
               <div className={`assignment-badge priority-${(item.priority || 'unassigned').toLowerCase()}`}>
-                {item.priority ? item.priority.charAt(0).toUpperCase() + item.priority.slice(1).toLowerCase() : 'Unassigned'}
+                {formatPriority(toPriorityKey(item.priority))}
               </div>
 
               <div className="assignment-content">
-                <h3 className="assignment-title">Ticket #{item.ticket_id}</h3>
+                <div className="assignment-ticket-header">
+                  <span className="assignment-ticket-id">#{item.ticket_id}</span>
+                  <h3 className="assignment-title">
+                    {item.ticket_title ?? `Ticket #${item.ticket_id}`}
+                  </h3>
+                </div>
                 <p className="assignment-message">
-                  <strong>Prioridad:</strong> {item.priority}
+                  {item.assigned_to
+                    ? `Asignación: ${agentMap.get(item.assigned_to) ?? item.assigned_to}`
+                    : 'No asignado'}
                 </p>
               </div>
 

--- a/frontend/src/test/assignments/AssignmentList.test.tsx
+++ b/frontend/src/test/assignments/AssignmentList.test.tsx
@@ -3,16 +3,35 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import AssignmentList from '../../pages/assignments/AssignmentList';
 import { assignmentsApi } from '../../services/assignment';
+import { ticketApi } from '../../services/ticketApi';
+import { userService } from '../../services/user';
 
-// Mock the API
+// Mock de la API de asignaciones
 vi.mock('../../services/assignment', () => ({
   assignmentsApi: {
     getAssignments: vi.fn(),
+    assignUser: vi.fn(),
     deleteAssignment: vi.fn(),
   },
 }));
 
-// Mock common components
+// Mock de la API de tickets
+vi.mock('../../services/ticketApi', () => ({
+  ticketApi: {
+    getTickets: vi.fn(),
+    getTicket: vi.fn(),
+    updateStatus: vi.fn(),
+  },
+}));
+
+// Mock del servicio de usuarios
+vi.mock('../../services/user', () => ({
+  userService: {
+    getAdminUsers: vi.fn(),
+  },
+}));
+
+// Mock de componentes comunes
 vi.mock('../../components/common', () => ({
   LoadingState: ({ message }: { message?: string }) => <div data-testid="loading-state">{message || 'Loading...'}</div>,
   EmptyState: ({ message }: { message: string }) => <div data-testid="empty-state">{message}</div>,
@@ -24,112 +43,136 @@ vi.mock('../../components/common', () => ({
   ),
 }));
 
+// Mock de componentes secundarios
+vi.mock('../../components/TicketAssign', () => ({
+  default: () => <div data-testid="ticket-assign" />,
+}));
+vi.mock('../../components/ConfirmModal', () => ({
+  default: () => <div data-testid="confirm-modal" />,
+}));
+
 const mockAssignments = [
   {
     id: 1,
-    ticket_id: 100,
-    user_id: 1,
+    ticket_id: '100',
     priority: 'HIGH',
     assigned_at: '2024-01-15T10:00:00Z',
+    assigned_to: 'agent-1',
   },
   {
     id: 2,
-    ticket_id: 101,
-    user_id: 1,
+    ticket_id: '101',
     priority: 'MEDIUM',
     assigned_at: '2024-01-14T10:00:00Z',
+    assigned_to: undefined,
   },
 ];
+
+const mockTickets = [
+  { id: 100, title: 'Error en login', description: 'desc', status: 'OPEN', user_id: '1', created_at: '2024-01-15T10:00:00Z' },
+  { id: 101, title: 'Pérdida de datos', description: 'desc', status: 'IN_PROGRESS', user_id: '2', created_at: '2024-01-14T10:00:00Z' },
+];
+
+const mockAdminUsers = [
+  { id: 'agent-1', username: 'carlos.gomez', email: 'c@test.com', role: 'ADMIN', is_active: true },
+];
+
+const renderComponent = () =>
+  render(
+    <BrowserRouter>
+      <AssignmentList />
+    </BrowserRouter>
+  );
 
 describe('AssignmentList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(ticketApi.getTickets).mockResolvedValue(mockTickets as never);
+    vi.mocked(userService.getAdminUsers).mockResolvedValue(mockAdminUsers);
   });
 
-  it('shows loading state initially', () => {
+  it('muestra estado de carga inicialmente', () => {
     vi.mocked(assignmentsApi.getAssignments).mockImplementation(() => new Promise(() => {}));
-
-    render(
-      <BrowserRouter>
-        <AssignmentList />
-      </BrowserRouter>
-    );
-
+    renderComponent();
     expect(screen.getByTestId('loading-state')).toBeInTheDocument();
   });
 
-  it('displays assignments after loading', async () => {
+  it('muestra el título del ticket en la tarjeta (no solo el ID)', async () => {
     vi.mocked(assignmentsApi.getAssignments).mockResolvedValue(mockAssignments);
-
-    render(
-      <BrowserRouter>
-        <AssignmentList />
-      </BrowserRouter>
-    );
-
+    renderComponent();
     await waitFor(() => {
-      expect(screen.getByText('Ticket #100')).toBeInTheDocument();
-      expect(screen.getByText('Ticket #101')).toBeInTheDocument();
+      expect(screen.getByText('Error en login')).toBeInTheDocument();
+      expect(screen.getByText('Pérdida de datos')).toBeInTheDocument();
     });
   });
 
-  it('shows empty state when no assignments', async () => {
+  it('muestra el badge #id junto al título', async () => {
+    vi.mocked(assignmentsApi.getAssignments).mockResolvedValue(mockAssignments);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('#100')).toBeInTheDocument();
+      expect(screen.getByText('#101')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra prioridad en español (Alta, Media)', async () => {
+    vi.mocked(assignmentsApi.getAssignments).mockResolvedValue(mockAssignments);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Alta')).toBeInTheDocument();
+      expect(screen.getByText('Media')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra nombre del agente cuando el ticket está asignado', async () => {
+    vi.mocked(assignmentsApi.getAssignments).mockResolvedValue(mockAssignments);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Asignación: carlos.gomez')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra "No asignado" cuando el ticket no tiene agente', async () => {
+    vi.mocked(assignmentsApi.getAssignments).mockResolvedValue(mockAssignments);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('No asignado')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra estado vacío cuando no hay asignaciones', async () => {
     vi.mocked(assignmentsApi.getAssignments).mockResolvedValue([]);
-
-    render(
-      <BrowserRouter>
-        <AssignmentList />
-      </BrowserRouter>
-    );
-
+    renderComponent();
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
     });
   });
 
-  it('displays correct assignment count in header', async () => {
+  it('muestra el contador correcto de tareas en el header', async () => {
     vi.mocked(assignmentsApi.getAssignments).mockResolvedValue(mockAssignments);
-
-    render(
-      <BrowserRouter>
-        <AssignmentList />
-      </BrowserRouter>
-    );
-
+    renderComponent();
     await waitFor(() => {
       expect(screen.getByText(/2 tareas/i)).toBeInTheDocument();
     });
   });
 
-  it('handles API errors gracefully', async () => {
+  it('maneja errores de API sin crashear', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(assignmentsApi.getAssignments).mockRejectedValue(new Error('API Error'));
-
-    render(
-      <BrowserRouter>
-        <AssignmentList />
-      </BrowserRouter>
-    );
-
+    renderComponent();
     await waitFor(() => {
-      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+      expect(screen.queryByTestId('loading-state')).not.toBeInTheDocument();
     });
-
     consoleSpy.mockRestore();
   });
 
-  it('displays priority badges correctly', async () => {
+  it('sigue funcionando si el servicio de usuarios falla', async () => {
     vi.mocked(assignmentsApi.getAssignments).mockResolvedValue(mockAssignments);
-
-    render(
-      <BrowserRouter>
-        <AssignmentList />
-      </BrowserRouter>
-    );
-
+    vi.mocked(userService.getAdminUsers).mockRejectedValue(new Error('Users service down'));
+    renderComponent();
+    // Debe mostrar los tickets aunque no se resuelva el nombre del agente
     await waitFor(() => {
-      expect(screen.getByText('HIGH')).toBeInTheDocument();
-      expect(screen.getByText('MEDIUM')).toBeInTheDocument();
+      expect(screen.getByText('Error en login')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Descripción

Unifica la presentación visual de la pestaña **Asignaciones** con la pestaña **Tickets** del panel de administración, resolviendo tres inconsistencias detectadas.

---

## Cambios realizados

### 1. Prioridad en español
Los labels de prioridad en el badge de cada tarjeta ahora se muestran en español, reutilizando `formatPriority` de `priorityUtils.ts` y normalizando cualquier casing recibido desde la API (`HIGH`, `high`, `High` → `Alta`).

| Antes | Después |
|---|---|
| `Unassigned` | `Sin Prioridad` |
| `Low` | `Baja` |
| `Medium` | `Media` |
| `High` | `Alta` |

### 2. Encabezado del ticket con badge azul `#id` + título
El título de la tarjeta ahora muestra el badge azul con el `#id` del ticket seguido del título real del ticket, igual que en la pestaña Tickets. El título se resuelve en tiempo de carga haciendo join local con los datos de `ticketApi.getTickets()`.

### 3. Descripción muestra estado de asignación
El campo de descripción deja de repetir la prioridad y pasa a mostrar:
- `Asignación: {username del agente}` cuando el ticket está asignado
- `No asignado` cuando no tiene agente

El nombre del agente se resuelve desde `userService.getAdminUsers()` con fallback al ID si el servicio no está disponible.

---

## Archivos modificados

- `frontend/src/pages/assignments/AssignmentList.tsx`
- `frontend/src/pages/assignments/AssignmentList.css`
- `frontend/src/test/assignments/AssignmentList.test.tsx`

---

## Tests

Se actualizó `AssignmentList.test.tsx` cubriendo:
- Labels de prioridad en español
- Badge `#id` + título del ticket en el encabezado
- Texto `Asignación: <agente>` cuando hay asignación
- Texto `No asignado` cuando no hay agente
- Resiliencia si el servicio de usuarios falla

---

Closes #118